### PR TITLE
changed range popup box-sizing

### DIFF
--- a/src/VueDatepickerLocal.vue
+++ b/src/VueDatepickerLocal.vue
@@ -288,6 +288,7 @@ export default {
 
 .datepicker-range .datepicker-popup{
   width: 403px;
+  box-sizing: content-box; // make range popup container include two datepicker for all application
 }
 
 .datepicker-bottom {

--- a/src/VueDatepickerLocal.vue
+++ b/src/VueDatepickerLocal.vue
@@ -288,7 +288,7 @@ export default {
 
 .datepicker-range .datepicker-popup{
   width: 403px;
-  box-sizing: content-box; // make range popup container include two datepicker for all application
+  box-sizing: content-box; /* make range popup container include two datepicker for all application */
 }
 
 .datepicker-bottom {


### PR DESCRIPTION
my system use reset.css for `box-sizing: border-box` for global css.  use vue-datepicker-local will display blow, so need control this css attribute in vue-datepicker-local

![image](https://user-images.githubusercontent.com/6310131/48608038-ffd3e380-e9bc-11e8-9bb5-9dc11d87b861.png)
